### PR TITLE
Docker compose to unless-stopped instead of always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ./blockr-validator_main/keys:/keys
        #volumes:
        # - ./blockr-validator_main/database_volume:/app/database
-    restart: always
+    restart: unless-stopped
     environment:
       - IS_BACKUP=false
       - P2P_SERVER_IP=p2p
@@ -50,7 +50,7 @@ services:
       - blockr
     volumes:
       - ./blockr-validator_backup/keys:/keys
-    restart: always
+    restart: unless-stopped
     environment:
       - IS_BACKUP=true
       - P2P_SERVER_IP=p2p


### PR DESCRIPTION
Replace the always within docker-compose to unless stopped. This will make sure the containers won't restart when they are manually stopped.